### PR TITLE
fixade en bugg där jag missat ha break; i switch

### DIFF
--- a/src/main/java/com/newtonprojectgroup/schoolmanagementsystem/Controller/AdminController.java
+++ b/src/main/java/com/newtonprojectgroup/schoolmanagementsystem/Controller/AdminController.java
@@ -217,6 +217,7 @@ public class AdminController {
                 staff.setPersonalNumber(requestToSave.getPersonalNumber());
                 staff.setPersonType(requestToSave.getPersonType());
                 repositoryStaff.save(staff);
+                break;
 
             case "ROLE_ADMIN":
                 Admin admin = new Admin();
@@ -228,6 +229,7 @@ public class AdminController {
                 admin.setPersonalNumber(requestToSave.getPersonalNumber());
                 admin.setPersonType(requestToSave.getPersonType());
                 repositoryAdmin.save(admin);
+                break;
 
             case "ROLE_TEACHER":
                 Teacher teacher = new Teacher();
@@ -239,6 +241,7 @@ public class AdminController {
                 teacher.setPersonalNumber(requestToSave.getPersonalNumber());
                 teacher.setPersonType(requestToSave.getPersonType());
                 repositoryTeacher.save(teacher);
+                break;
 
             default:
                 // add case for each personType and add the person to the suiting table as I've done with student.


### PR DESCRIPTION
Där förfrågningar skall hanteras av en administratör finns en switchhsats som sparar kontot beroende på vilken behörighetstyp kontot skall ha. Dett görs via en switchsats, den switchsatsen saknade break; i slutet av två case vilket orsakade ett felmeddelande då detta ledde till att en kontoförfrågning kunde försöka spara flera gånger med samma primära nyckel.